### PR TITLE
Catch the error in GET, and if there's a error return nothing.

### DIFF
--- a/breadbox.js
+++ b/breadbox.js
@@ -175,7 +175,7 @@ class breadbox {
     };
 
     fetchFromURL({URL}) {
-        return fetch(URL).then(response => response.text());
+        return fetch(URL).then(response => response.text()).catch(err => '');
     };
 
     startsWith({VAL1, VAL2}) {


### PR DESCRIPTION
Basically some cool way of catching errors instead of returning `undefined`.